### PR TITLE
fix: @asyncio.coroutine no longer exists in python 3.11

### DIFF
--- a/custom_components/pfsense_gateways/sensor.py
+++ b/custom_components/pfsense_gateways/sensor.py
@@ -54,7 +54,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 
-@asyncio.coroutine
 async def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the pfSense sensor."""
     name = config.get(CONF_NAME)


### PR DESCRIPTION
@asyncio.coroutine no longer exists in Python 3.11. This will break the integration in Home Assistant > 2023.6.0. The coroutine definition is already async, no need to change it.